### PR TITLE
스터디 게시판 상세 조회 기능 구현

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
@@ -1,5 +1,6 @@
 package com.codewarts.noriter.article.controller;
 
+import com.codewarts.noriter.article.domain.dto.study.StudyDetailResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyListResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyPostRequest;
 import com.codewarts.noriter.article.service.StudyService;
@@ -8,6 +9,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +34,11 @@ public class StudyController {
 
     @GetMapping
     public List<StudyListResponse> gatheringList(@RequestParam(required = false) Boolean completed) {
-        return studyService.findStudyList(completed);
+        return studyService.findList(completed);
+    }
+
+    @GetMapping("/{id}")
+    public StudyDetailResponse gatheringDetail(@PathVariable Long id) {
+        return studyService.findDetail(id);
     }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyDetailResponse.java
@@ -1,0 +1,44 @@
+package com.codewarts.noriter.article.domain.dto.study;
+
+import com.codewarts.noriter.article.domain.Hashtag;
+import com.codewarts.noriter.article.domain.Study;
+import com.codewarts.noriter.comment.domain.dto.CommentResponse;
+import com.codewarts.noriter.common.domain.dto.WriterInfoResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StudyDetailResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private WriterInfoResponse writer;
+    private List<String> hashtag;
+    private LocalDateTime writtenTime;
+    private LocalDateTime editedTime;
+    private int wishCount;
+    private boolean completed;
+    private List<CommentResponse> comment;
+
+    public StudyDetailResponse(Study study) {
+        this.id = study.getId();
+        this.title = study.getTitle();
+        this.content = study.getContent();
+        this.writer = new WriterInfoResponse(study.getWriter());
+        this.hashtag = study.getHashtags().stream()
+            .map(Hashtag::getContent)
+            .collect(Collectors.toList());
+        this.writtenTime = study.getWrittenTime();
+        this.editedTime = study.getEditedTime();
+        this.wishCount = study.getWishList().size();
+        this.completed = study.isCompleted();
+        this.comment = study.getComments().stream()
+            .map(CommentResponse::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/noriter/src/main/java/com/codewarts/noriter/article/repository/ArticleRepository.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/repository/ArticleRepository.java
@@ -11,13 +11,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
+    @Query("select a from Article a where a.articleType = :articleType")
+    List<Article> findAllByArticleType(@Param("articleType") ArticleType articleType);
+
     @Query("select s from Study s where s.completed = :completed")
     List<Study> findStudyByCompleted(@Param("completed") boolean completed);
 
-    @Query("select a from Article a where a.articleType = :articleType")
-    List<Article> findAllByArticleType(@Param("articleType") ArticleType articleType);
+    @Query("select s from Study s where s.id =:id")
+    Study findByStudyId(@Param("id") Long id);
+
     @Query("select q from Question q")
     List<Question> findAllQuestion();
+
     @Query("select q from Question q where q.completed = :status")
     List<Question> findQuestionByCompleted(@Param("status") boolean status);
 }

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
@@ -2,6 +2,7 @@ package com.codewarts.noriter.article.service;
 
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.Study;
+import com.codewarts.noriter.article.domain.dto.study.StudyDetailResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyListResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyPostRequest;
 import com.codewarts.noriter.article.domain.type.ArticleType;
@@ -31,7 +32,7 @@ public class StudyService {
         articleRepository.save(study);
     }
 
-    public List<StudyListResponse> findStudyList(Boolean completed) {
+    public List<StudyListResponse> findList(Boolean completed) {
 
         if (completed == null) {
             List<Article> allByArticleType = articleRepository.findAllByArticleType(
@@ -45,5 +46,10 @@ public class StudyService {
         return allStudy.stream()
             .map(StudyListResponse::new)
             .collect(Collectors.toList());
+    }
+
+    public StudyDetailResponse findDetail(Long id) {
+        Study study = articleRepository.findByStudyId(id);
+        return new StudyDetailResponse(study);
     }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
@@ -11,9 +11,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
 
@@ -29,6 +31,7 @@ public class Comment {
   @JoinColumn
   private Member writer;
 
+  private String content;
   private boolean secret;
   private boolean deleted;
   private LocalDateTime writtenTime;

--- a/noriter/src/main/java/com/codewarts/noriter/comment/domain/dto/CommentResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/domain/dto/CommentResponse.java
@@ -1,0 +1,21 @@
+package com.codewarts.noriter.comment.domain.dto;
+
+import com.codewarts.noriter.comment.domain.Comment;
+import com.codewarts.noriter.common.domain.dto.WriterInfoResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponse {
+
+    private Long id;
+    private String content;
+    private WriterInfoResponse writer;
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.writer = new WriterInfoResponse(comment.getWriter());
+    }
+}

--- a/noriter/src/main/java/com/codewarts/noriter/common/domain/dto/WriterInfoResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/common/domain/dto/WriterInfoResponse.java
@@ -1,0 +1,20 @@
+package com.codewarts.noriter.common.domain.dto;
+
+import com.codewarts.noriter.common.domain.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WriterInfoResponse {
+
+    private Long id;
+    private String nickname;
+    private String profileImage;
+
+    public WriterInfoResponse(Member member) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.profileImage = member.getProfileImageUrl();
+    }
+}

--- a/noriter/src/main/resources/data.sql
+++ b/noriter/src/main/resources/data.sql
@@ -1,8 +1,12 @@
 INSERT INTO members
     (id, email, nickname, profile_image_url, refresh_token, resource_server, resource_server_id)
-VALUES (1, 'olx.rko.o@gmail.com', 'rkolx', 'https://avatars.githubusercontent.com/u/92699009?v=4',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2Njg5MTUwMjA5fQ.ljyiSCdelyGB_DDXNBC-yQh0A7uQ38IhzQ4OuBOboY0',
-        'GITHUB', 92699009);
+VALUES
+    (1, 'olx.rko.o@gmail.com', 'rkolx', 'https://avatars.githubusercontent.com/u/92699009?v=4',
+     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NjExMzExODEsImF1ZCI6IjkyNjk5MDA5IiwiZXhwIjoxNjY4OTE1MDIwOSwibWVtYmVySWQiOjkyNjk5MDA5LCJpc3MiOiIxc2VwaGlsIiwic3ViIjoiUmVmcmVzaC1Ub2tlbiJ9.WTIn5iPi5k9LIsFPKN4LpmK7nFm69glsJ4xU-vEqmDc',
+     'GITHUB', 92699009),
+    (2, 'peelhw@gmail.com', 'philsogooood', 'https://avatars.githubusercontent.com/u/87455844?v=4',
+     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NjExMzExODEsImF1ZCI6Ijg3NDU1ODQ0IiwiZXhwIjoxNjY4OTE1MDIwOSwibWVtYmVySWQiOjg3NDU1ODQ0LCJpc3MiOiIxc2VwaGlsIiwic3ViIjoiUmVmcmVzaC1Ub2tlbiJ9.OuH6NJnCcCZBMWu_BvxVFKhxccx3FvkWc6j2EsHa60c',
+     'GITHUB', 87455844);
 
 
 INSERT INTO article
@@ -22,4 +26,12 @@ VALUES
     (3, false),
     (4, true),
     (5, false);
+
+INSERT INTO comment
+    (id, content, deleted, secret, writer_id, article_id, written_time, edited_time)
+VALUES
+    (1, '우왕 잘봤어용', false, false, 2, 1, '2022-11-12 16:25:58.991061', '2022-11-12 16:25:58.991061'),
+    (2, '우왕 잘봤어용2', false, false, 2, 1, '2022-11-12 17:25:58.991061', '2022-11-12 17:25:58.991061'),
+    (3, '우왕 잘봤어3', false, false, 2, 1, '2022-11-12 19:25:58.991061', '2022-11-12 19:25:58.991061'),
+    (4, '우왕 잘봤어용4', false, false, 2, 1, '2022-11-13 16:25:58.991061', '2022-11-13 16:25:58.991061');
 


### PR DESCRIPTION
## 📃 Description
💬 스터디 게시판 리스트를 조회한다.

## ➡️ Request

### Header

GET `/community/gathering/{id}`

### Body

```json
{}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{
	"id" : 1,
	"title" : "자유게시판 제목",
	"content" : "자유게시판 내용", //글자 수 제한
	"wrtierName" : "필바보",
	"hashtag": ["키보드", "적축"],
	"writtenTime" : "2022-12-30 14:00",
	"editedTime" : "2022-12-30 14:00",	"wishCount" : 3,
	"completion" : true
	"comment" : [
		{ 
			"id" : 1,
			"writerId" : 2,
			"comment" : "글 잘봤어요~"
		},
		{ 
			"id" : 2,
			"writerId" : 5,
			"comment" : "글 잘봤어요~"
		}
	]
}
```

## ☑ Todo


## etc
