### PR TITLE
게시글 편집 기능 구현

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
@@ -55,4 +55,10 @@ public class StudyController {
         Long memberId = jwtProvider.decode(request.getHeader("Authorization"));
         studyService.updateCompletion(id, memberId);
     }
+
+    @PutMapping("/{id}")
+    public void postEdit(@PathVariable Long id, @RequestBody StudyEditRequest studyEditRequest,HttpServletRequest request) {
+        Long memberId = jwtProvider.decode(request.getHeader("Authorization"));
+        studyService.update(id, studyEditRequest, memberId);
+    }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
@@ -1,11 +1,13 @@
 package com.codewarts.noriter.article.controller;
 
 import com.codewarts.noriter.article.domain.dto.study.StudyDetailResponse;
+import com.codewarts.noriter.article.domain.dto.study.StudyEditRequest;
 import com.codewarts.noriter.article.domain.dto.study.StudyListResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyPostRequest;
 import com.codewarts.noriter.article.service.StudyService;
 import com.codewarts.noriter.auth.jwt.JwtProvider;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,13 +54,15 @@ public class StudyController {
     }
 
     @PatchMapping("/{id}")
-    public void recruitmentCompletionUpdate(@PathVariable Long id, HttpServletRequest request) {
+    public void recruitmentCompletionUpdate(@PathVariable Long id,
+        @RequestBody Map<String, Boolean> map, HttpServletRequest request) {
         Long memberId = jwtProvider.decode(request.getHeader("Authorization"));
-        studyService.updateCompletion(id, memberId);
+        studyService.updateCompletion(id, memberId, map.get("completion"));
     }
 
     @PutMapping("/{id}")
-    public void postEdit(@PathVariable Long id, @RequestBody StudyEditRequest studyEditRequest,HttpServletRequest request) {
+    public void postEdit(@PathVariable Long id, @RequestBody StudyEditRequest studyEditRequest,
+        HttpServletRequest request) {
         Long memberId = jwtProvider.decode(request.getHeader("Authorization"));
         studyService.update(id, studyEditRequest, memberId);
     }

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/Article.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/Article.java
@@ -1,9 +1,9 @@
 package com.codewarts.noriter.article.domain;
 
-import com.codewarts.noriter.article.domain.type.ArticleType;
 import com.codewarts.noriter.comment.domain.Comment;
 import com.codewarts.noriter.common.domain.Member;
 import com.codewarts.noriter.wish.domain.Wish;
+import com.codewarts.noriter.article.domain.type.ArticleType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,9 +80,9 @@ public class Article {
         }
     }
 
-    protected void update(String newTitle, String newContent , List<String> requestHashtags) {
-        this.title = newTitle;
-        this.content = newContent;
+    public void update(String title, String content, List<String> requestHashtags) {
+        this.title = title;
+        this.content = content;
         this.editedTime = LocalDateTime.now();
         this.hashtags.clear();
         addHashtags(requestHashtags);

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/Study.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/Study.java
@@ -2,6 +2,7 @@ package com.codewarts.noriter.article.domain;
 
 import com.codewarts.noriter.article.domain.type.ArticleType;
 import com.codewarts.noriter.common.domain.Member;
+import java.util.List;
 import javax.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,5 +24,14 @@ public class Study extends Article {
 
     public void completion() {
         completed = true;
+    }
+
+    public void incomplete() {
+        completed = false;
+    }
+
+    @Override
+    public void update(String title, String content, List<String> requestHashtags) {
+        super.update(title, content, requestHashtags);
     }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyEditRequest.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyEditRequest.java
@@ -1,0 +1,15 @@
+package com.codewarts.noriter.article.domain.dto.study;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StudyEditRequest {
+
+    private String title;
+    private String content;
+    private List<String> hashtags;
+
+}

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
@@ -60,10 +60,14 @@ public class StudyService {
     }
 
     @Transactional
-    public void updateCompletion(Long id, Long writerId) {
+    public void updateCompletion(Long id, Long writerId, boolean completion) {
         Study study = articleRepository.findByStudyIdAndWriterId(id, writerId)
             .orElseThrow(RuntimeException::new);
-        study.completion();
+
+        if (completion) {study.completion();
+        } else {
+            study.incomplete();
+        }
     }
 
     @Transactional

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
@@ -3,6 +3,7 @@ package com.codewarts.noriter.article.service;
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.Study;
 import com.codewarts.noriter.article.domain.dto.study.StudyDetailResponse;
+import com.codewarts.noriter.article.domain.dto.study.StudyEditRequest;
 import com.codewarts.noriter.article.domain.dto.study.StudyListResponse;
 import com.codewarts.noriter.article.domain.dto.study.StudyPostRequest;
 import com.codewarts.noriter.article.domain.type.ArticleType;
@@ -63,5 +64,12 @@ public class StudyService {
         Study study = articleRepository.findByStudyIdAndWriterId(id, writerId)
             .orElseThrow(RuntimeException::new);
         study.completion();
+    }
+
+    @Transactional
+    public void update(Long id, StudyEditRequest request, Long writerId) {
+        Study study = articleRepository.findByStudyIdAndWriterId(id, writerId)
+            .orElseThrow(RuntimeException::new);
+        study.update(request.getTitle(), request.getContent(), request.getHashtags());
     }
 }

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyCreateTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyCreateTest.java
@@ -26,14 +26,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @ExtendWith({RestDocumentationExtension.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile({"test"})
+@Sql("classpath:/data.sql")
 class StudyCreateTest {
 
     @LocalServerPort

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyDeleteTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyDeleteTest.java
@@ -1,0 +1,82 @@
+package com.codewarts.noriter.article.docs.study;
+
+import static io.restassured.RestAssured.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONNECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.DATE;
+import static org.springframework.http.HttpHeaders.HOST;
+import static org.springframework.http.HttpHeaders.TRANSFER_ENCODING;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.codewarts.noriter.auth.jwt.JwtProvider;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith({RestDocumentationExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql("classpath:/data.sql")
+class StudyDeleteTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected RequestSpecification documentationSpec;
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        documentationSpec = new RequestSpecBuilder()
+            .addFilter(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(HOST, CONTENT_LENGTH))
+                    .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(CONTENT_LENGTH, CONNECTION, DATE, TRANSFER_ENCODING,
+                            "Keep-Alive",
+                            HttpHeaders.VARY))
+            )
+            .build();
+    }
+
+    @Test
+    void 게시글을_삭제한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("id", 1)
+
+            .when()
+            .delete("/community/gathering/{id}")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+}

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyEditTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyEditTest.java
@@ -1,0 +1,88 @@
+package com.codewarts.noriter.article.docs.study;
+
+import static io.restassured.RestAssured.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONNECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.DATE;
+import static org.springframework.http.HttpHeaders.HOST;
+import static org.springframework.http.HttpHeaders.TRANSFER_ENCODING;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.codewarts.noriter.auth.jwt.JwtProvider;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith({RestDocumentationExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql("classpath:/data.sql")
+class StudyEditTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected RequestSpecification documentationSpec;
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        documentationSpec = new RequestSpecBuilder()
+            .addFilter(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(HOST, CONTENT_LENGTH))
+                    .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(CONTENT_LENGTH, CONNECTION, DATE, TRANSFER_ENCODING,
+                            "Keep-Alive",
+                            HttpHeaders.VARY))
+            )
+            .build();
+    }
+
+    @Test
+    void 글을_수정한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("title", "내가 글을 수정해볼게",
+            "content", "하나둘셋 얍", "hashtags", List.of("ㄱㄴㄱㄴ", "얍", "모여라"));
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("id", 1)
+            .body(requestBody)
+
+            .when()
+            .put("/community/gathering/{id}")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+}

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyUpdateCompletionTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyUpdateCompletionTest.java
@@ -29,10 +29,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @ExtendWith({RestDocumentationExtension.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql("classpath:/data.sql")
 class StudyUpdateCompletionTest {
 
     @LocalServerPort

--- a/noriter/src/test/resources/application-test.yml
+++ b/noriter/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     defer-datasource-initialization: true
   sql:
     init:

--- a/noriter/src/test/resources/data.sql
+++ b/noriter/src/test/resources/data.sql
@@ -1,3 +1,12 @@
+DELETE from image;
+DELETE from hashtag;
+DELETE from wish;
+DELETE from comment;
+DELETE from question;
+DELETE from study;
+DELETE from article;
+DELETE from members;
+
 INSERT INTO members
     (id, email, nickname, profile_image_url, refresh_token, resource_server, resource_server_id)
 VALUES


### PR DESCRIPTION
## 📃 Description
💬 스터디게시판에 글을 편집한다

## ➡️ Request

### Header

Authorization : `AccessToken`

PUT `/community/gathering/{id}`

### Body

```json
{
	"title" : "자유게시판 제목을 변경할거에요",
	"content" : "자유게시판 내용을 변결할가요?",
	"hashtag": ["키보드", "적축"]
}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{}
```

## ☑ Todo
- [x] 테스트 격리
- [x] 잘못 구현한 스터디 모집 상태 변경 기능 수정
- [x] 삭제 기능 테스트 생성   

## etc
