### PR TITLE
자유 게시판 리스트 기능 구현

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/FreeController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/FreeController.java
@@ -2,9 +2,11 @@ package com.codewarts.noriter.article.controller;
 
 
 import com.codewarts.noriter.article.domain.dto.free.FreeDetailResponse;
+import com.codewarts.noriter.article.domain.dto.free.FreeListResponse;
 import com.codewarts.noriter.article.domain.dto.free.FreePostRequest;
 import com.codewarts.noriter.article.service.FreeService;
 import com.codewarts.noriter.auth.jwt.JwtProvider;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,4 +34,10 @@ public class FreeController {
     public FreeDetailResponse freeDetail(@PathVariable Long id) {
         return freeService.findDetail(id);
     }
+
+    @GetMapping()
+    public List<FreeListResponse> freeDetail() {
+        return freeService.findList();
+    }
+
 }

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeListResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeListResponse.java
@@ -1,0 +1,41 @@
+package com.codewarts.noriter.article.domain.dto.free;
+
+import com.codewarts.noriter.article.domain.Article;
+import com.codewarts.noriter.article.domain.Hashtag;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FreeListResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+
+    private String writerNickname;
+    private List<String> hashtag;
+    private LocalDateTime writtenTime;
+    private LocalDateTime editedTime;
+    private int wishCount;
+    private int commentCount;
+    private boolean completed;
+
+    public FreeListResponse(Article article) {
+        this.id = article.getId();
+        this.title = article.getTitle();
+        this.content = article.getContent();
+        this.writerNickname = article.getWriter().getNickname();
+        this.hashtag = article.getHashtags().stream()
+            .map(Hashtag::getContent)
+            .collect(Collectors.toList());
+        this.writtenTime = article.getWrittenTime();
+        this.editedTime = article.getWrittenTime();
+        this.wishCount = article.getWishList().size();
+        this.commentCount = article.getComments().size();
+        this.completed = isCompleted();
+    }
+}

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyListResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyListResponse.java
@@ -16,6 +16,8 @@ public class StudyListResponse {
     private Long id;
     private String title;
     private String content;
+
+    private String writerNickname;
     private List<String> hashtag;
     private LocalDateTime writtenTime;
     private LocalDateTime editedTime;
@@ -27,6 +29,7 @@ public class StudyListResponse {
         this.id = study.getId();
         this.title = study.getTitle();
         this.content = study.getContent();
+        this.writerNickname = study.getWriter().getNickname();
         this.hashtag = study.getHashtags().stream().map(Hashtag::getContent).collect(Collectors.toList());
         this.writtenTime = study.getWrittenTime();
         this.editedTime = study.getEditedTime();
@@ -39,6 +42,7 @@ public class StudyListResponse {
         this.id = article.getId();
         this.title = article.getTitle();
         this.content = article.getContent();
+        this.writerNickname = article.getWriter().getNickname();
         this.hashtag = article.getHashtags().stream().map(Hashtag::getContent).collect(Collectors.toList());
         this.writtenTime = article.getWrittenTime();
         this.editedTime = article.getEditedTime();

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/FreeService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/FreeService.java
@@ -2,10 +2,14 @@ package com.codewarts.noriter.article.service;
 
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.dto.free.FreeDetailResponse;
+import com.codewarts.noriter.article.domain.dto.free.FreeListResponse;
 import com.codewarts.noriter.article.domain.dto.free.FreePostRequest;
+import com.codewarts.noriter.article.domain.type.ArticleType;
 import com.codewarts.noriter.article.repository.ArticleRepository;
 import com.codewarts.noriter.common.domain.Member;
 import com.codewarts.noriter.common.repository.MemberRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,5 +33,10 @@ public class FreeService {
     public FreeDetailResponse findDetail(Long id) {
         Article article = articleRepository.findById(id).orElseThrow(RuntimeException::new);
         return new FreeDetailResponse(article);
+    }
+
+    public List<FreeListResponse> findList() {
+        List<Article> freeTypeArticle = articleRepository.findAllByArticleType(ArticleType.FREE);
+        return freeTypeArticle.stream().map(FreeListResponse::new).collect(Collectors.toList());
     }
 }

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeListTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeListTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.jdbc.Sql;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Profile({"test"})
 @Sql("classpath:/data.sql")
-public class FreeDetailTest {
+public class FreeListTest {
 
     @LocalServerPort
     int port;
@@ -66,37 +66,29 @@ public class FreeDetailTest {
     }
 
     @Test
-    void 상세조회를_한다() {
+    void 리스트를_조회한다() {
 
         given(documentationSpec)
             .contentType(APPLICATION_JSON_VALUE)
-            .pathParam("id", 10)
 
             .when()
-            .get("/community/free/{id}")
+            .get("/community/free")
 
             .then()
             .statusCode(HttpStatus.OK.value())
-            .body("id", equalTo(10))
-            .body("title", equalTo("붕어빵 먹고싶어요"))
-            .body("content", equalTo("강남 붕어빵 맛잇는 집"))
-            .body("writer.id", equalTo(2))
-            .body("writer.nickname", equalTo("admin2"))
-            .body("writer.profileImage",
-                equalTo("https://avatars.githubusercontent.com/u/222222?v=4"))
-            .body("hashtag[0]", equalTo("강남역"))
-            .body("hashtag[1]", equalTo("붕어팥"))
-            .body("hashtag[2]", equalTo("팥"))
-            .body("hashtag[3]", equalTo("슈크림"))
-            .body("hashtag[4]", equalTo("겨울"))
-            .body("writtenTime", equalTo("2022-11-25T16:25:58.991061"))
-            .body("editedTime", equalTo("2022-11-25T16:25:58.991061"))
-            .body("wishCount", equalTo(0))
-            .body("comment[0].id", equalTo(5))
-            .body("comment[0].content", equalTo("강남역 11번출구에서 팔아요"))
-            .body("comment[0].writer.id", equalTo(1))
-            .body("comment[0].writer.nickname", equalTo("admin1"))
-            .body("comment[0].writer.profileImage", equalTo("https://avatars.githubusercontent.com/u/111111?v=4"));
+            .body("[0].id", equalTo(10))
+            .body("[0].title", equalTo("붕어빵 먹고싶어요"))
+            .body("[0].content", equalTo("강남 붕어빵 맛잇는 집"))
+            .body("[0].writerNickname", equalTo("admin2"))
+            .body("[0].hashtag[0]", equalTo("강남역"))
+            .body("[0].hashtag[1]", equalTo("붕어팥"))
+            .body("[0].hashtag[2]", equalTo("팥"))
+            .body("[0].hashtag[3]", equalTo("슈크림"))
+            .body("[0].hashtag[4]", equalTo("겨울"))
+            .body("[0].writtenTime", equalTo("2022-11-25T16:25:58.991061"))
+            .body("[0].editedTime", equalTo("2022-11-25T16:25:58.991061"))
+            .body("[0].wishCount", equalTo(0))
+            .body("[0].commentCount", equalTo(1));
     }
 
 }


### PR DESCRIPTION
## 📃 Description
💬 자유 게시판 리스트를 조회한다.

## ➡️ Request

### Header

GET `/community/playground`

### Body

```json
{}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
[
	{
		"id" : 1,
		"title" : "자유게시판 제목",
		"content" : "자유게시판 내용", //글자 수 제한
		"wrtierName" : "필바보",
		"hashtag": ["키보드", "적축"],
		"writtenTime" : "2022-12-30 14:00",
		"editedTime" : "2022-12-30 14:00",
		"wish": : true, //나의 찜여부
		"wishCount" : 3,
		"commentCount" : 4 
	},
	{
		"id" : 3,
		"title" : "자유게시판 제목2",
		"content" : "자유게시판 내용2", //글자 수 제한
		"wrtierName" : "필필필",
		"hashtag": ["키보드", "적축"],
		"writtenTime" : "2022-12-30 14:00",
		"editedTime" : "2022-12-30 14:00",
		"wish": : true, //나의 찜여부
		"wishCount" : 3,
		"commentCount" : 4 
	},
	{
		"id" : 5,
		"title" : "자유게시판 제목3",
		"content" : "자유게시판 내용3", //글자 수 제한
		"wrtierName" : "한세필",
		"hashtag": ["키보드", "적축"],
		"writtenTime" : "2022-12-30 14:00",
		"editedTime" : "2022-12-30 14:00",
		"wish": : true, //나의 찜여부
		"wishCount" : 3,
		"commentCount" : 0 
	}
]
```

## ☑ Todo


## etc
