### PR TITLE
날짜 포맷팅 적용, 게시판 글 등록 시 게시판id 반환하도록 수정

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/FreeController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/FreeController.java
@@ -32,10 +32,10 @@ public class FreeController {
     private final FreeService freeService;
 
     @PostMapping
-    public void register(@RequestBody @Valid FreePostRequest freePostRequest,
+    public Long register(@RequestBody @Valid FreePostRequest freePostRequest,
         HttpServletRequest request) {
         Long memberId = getMemberId(request);
-        freeService.create(freePostRequest, memberId);
+        return freeService.create(freePostRequest, memberId);
     }
 
     @GetMapping("/{id}")

--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/QuestionController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/QuestionController.java
@@ -39,10 +39,10 @@ public class QuestionController {
     private final ConversionService conversionService;
 
     @PostMapping
-    public void create(@RequestBody @Valid QuestionPostRequest postRequest,
+    public Long register(@RequestBody @Valid QuestionPostRequest postRequest,
         HttpServletRequest request) {
         Long memberId = getMemberId(request);
-        questionService.add(postRequest, memberId);
+        return questionService.create(postRequest, memberId);
     }
 
     @GetMapping

--- a/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/controller/StudyController.java
@@ -39,10 +39,10 @@ public class StudyController {
     private final ConversionService conversionService;
 
     @PostMapping
-    public void register(@RequestBody @Valid StudyPostRequest studyPostRequest,
+    public Long register(@RequestBody @Valid StudyPostRequest studyPostRequest,
         HttpServletRequest request) {
         Long memberId = getMemberId(request);
-        studyService.register(studyPostRequest, memberId);
+        return studyService.create(studyPostRequest, memberId);
     }
 
     @GetMapping

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeDetailResponse.java
@@ -4,6 +4,7 @@ import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.Hashtag;
 import com.codewarts.noriter.comment.domain.dto.CommentResponse;
 import com.codewarts.noriter.member.domain.dto.WriterInfoResponse;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,10 +19,11 @@ public class FreeDetailResponse {
     private String title;
     private String content;
     private WriterInfoResponse writer;
-
     private boolean sameWriter;
     private List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime editedTime;
     private int wishCount;
     private List<CommentResponse> comment;

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeListResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/free/FreeListResponse.java
@@ -2,6 +2,7 @@ package com.codewarts.noriter.article.domain.dto.free;
 
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.Hashtag;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,7 +21,9 @@ public class FreeListResponse {
 
     private boolean sameWriter;
     private List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime editedTime;
     private int wishCount;
     private int commentCount;

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/question/QuestionDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/question/QuestionDetailResponse.java
@@ -5,6 +5,7 @@ import com.codewarts.noriter.article.domain.Question;
 import com.codewarts.noriter.article.domain.type.StatusType;
 import com.codewarts.noriter.comment.domain.dto.CommentResponse;
 import com.codewarts.noriter.member.domain.dto.WriterInfoResponse;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +20,9 @@ public class QuestionDetailResponse {
     private final WriterInfoResponse writer;
     private final boolean sameWriter;
     private final List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime editedTime;
     private final int wishCount;
     private final List<CommentResponse> comment;

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/question/QuestionListResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/question/QuestionListResponse.java
@@ -3,6 +3,7 @@ package com.codewarts.noriter.article.domain.dto.question;
 import com.codewarts.noriter.article.domain.Hashtag;
 import com.codewarts.noriter.article.domain.Question;
 import com.codewarts.noriter.article.domain.type.StatusType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,10 +14,13 @@ public class QuestionListResponse {
 
     private final Long id;
     private final String title;
-    private final String writerName;
+    private final String content;
+    private final String writerNickname;
     private final boolean sameWriter;
     private final List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime editedTime;
     private final int wishCount;
     private final int commentCount;
@@ -25,7 +29,8 @@ public class QuestionListResponse {
     public QuestionListResponse(Question question, boolean sameWriter) {
         this.id = question.getId();
         this.title = question.getTitle();
-        this.writerName = question.getWriter().getNickname();
+        this.content = question.getContent();
+        this.writerNickname = question.getWriter().getNickname();
         this.sameWriter = sameWriter;
         this.hashtags = question.getHashtags().stream().map(Hashtag::getContent).collect(Collectors.toList());
         this.writtenTime = question.getWrittenTime();

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyDetailResponse.java
@@ -5,6 +5,7 @@ import com.codewarts.noriter.article.domain.Study;
 import com.codewarts.noriter.article.domain.type.StatusType;
 import com.codewarts.noriter.comment.domain.dto.CommentResponse;
 import com.codewarts.noriter.member.domain.dto.WriterInfoResponse;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,7 +22,9 @@ public class StudyDetailResponse {
     private WriterInfoResponse writer;
     private boolean sameWriter;
     private List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime editedTime;
     private int wishCount;
     private StatusType status;

--- a/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyListResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/domain/dto/study/StudyListResponse.java
@@ -3,6 +3,7 @@ package com.codewarts.noriter.article.domain.dto.study;
 import com.codewarts.noriter.article.domain.Hashtag;
 import com.codewarts.noriter.article.domain.Study;
 import com.codewarts.noriter.article.domain.type.StatusType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +20,9 @@ public class StudyListResponse {
     private String writerNickname;
     private boolean sameWriter;
     private List<String> hashtags;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime writtenTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime editedTime;
     private int wishCount;
     private int commentCount;

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/FreeService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/FreeService.java
@@ -27,11 +27,11 @@ public class FreeService {
     private final ArticleUtils articleUtils;
 
     @Transactional
-    public void create(FreePostRequest freePostRequest, Long writerId) {
+    public Long create(FreePostRequest freePostRequest, Long writerId) {
         Member member = memberService.findMember(writerId);
         Article free = freePostRequest.toEntity(member);
         free.addHashtags(freePostRequest.getHashtags());
-        articleRepository.save(free);
+        return articleRepository.save(free).getId();
     }
 
     public FreeDetailResponse findDetail(Long id, String accessToken) {

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/QuestionService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/QuestionService.java
@@ -30,12 +30,11 @@ public class QuestionService {
 
     // 질문 등록 기능
     @Transactional
-    public Long add(QuestionPostRequest request, Long memberId) {
+    public Long create(QuestionPostRequest request, Long memberId) {
         Member writer = memberService.findMember(memberId);
         Question question = request.toEntity(writer);
         question.addHashtags(request.getHashtags());
-        Question savedQuestion = questionRepository.save(question);
-        return savedQuestion.getId();
+        return questionRepository.save(question).getId();
     }
 
     // 질문 조회 기능

--- a/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/service/StudyService.java
@@ -29,11 +29,11 @@ public class StudyService {
     private final ArticleUtils articleUtils;
 
     @Transactional
-    public void register(StudyPostRequest studyPostRequest, Long memberId) {
+    public Long create(StudyPostRequest studyPostRequest, Long memberId) {
         Member member = memberService.findMember(memberId);
         Study study = studyPostRequest.toEntity(member);
         study.addHashtags(studyPostRequest.getHashtags());
-        studyRepository.save(study);
+        return studyRepository.save(study).getId();
     }
 
     public List<StudyListResponse> findList(StatusType status, String accessToken) {

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeDetailTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeDetailTest.java
@@ -87,8 +87,8 @@ class FreeDetailTest {
             .body("writer.profileImage",
                 equalTo("https://avatars.githubusercontent.com/u/111111?v=4"))
             .body("sameWriter", equalTo(false))
-            .body("hashtag[0]", equalTo("강남역"))
-            .body("hashtag[1]", equalTo("붕어팥"))
+            .body("hashtags[0]", equalTo("강남역"))
+            .body("hashtags[1]", equalTo("붕어팥"))
             .body("wishCount", equalTo(0))
             .body("comment[0].id", equalTo(5))
             .body("comment[0].content", equalTo("강남역 11번출구에서 팔아요"))

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeListTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/free/FreeListTest.java
@@ -81,8 +81,10 @@ public class FreeListTest {
             .body("[0].content", equalTo("강남 붕어빵 맛잇는 집"))
             .body("[0].writerNickname", equalTo("admin1"))
             .body("[0].sameWriter", equalTo(false))
-            .body("[0].hashtag[0]", equalTo("강남역"))
-            .body("[0].hashtag[1]", equalTo("붕어팥"))
+            .body("[0].writtenTime", equalTo("2022-11-25 16:25:58"))
+            .body("[0].editedTime", equalTo("2022-11-25 16:25:58"))
+            .body("[0].hashtags[0]", equalTo("강남역"))
+            .body("[0].hashtags[1]", equalTo("붕어팥"))
             .body("[0].wishCount", equalTo(0))
             .body("[0].commentCount", equalTo(1));
     }

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/question/QuestionDetailTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/question/QuestionDetailTest.java
@@ -87,9 +87,9 @@ class QuestionDetailTest {
             .body("writer.profileImage",
                 equalTo("https://avatars.githubusercontent.com/u/111111?v=4"))
             .body("sameWriter", equalTo(false))
-            .body("hashtag[0]", equalTo("스프링"))
-            .body("hashtag[1]", equalTo("코린이"))
-            .body("hashtag[2]", equalTo("도와줘요"));
+            .body("hashtags[0]", equalTo("스프링"))
+            .body("hashtags[1]", equalTo("코린이"))
+            .body("hashtags[2]", equalTo("도와줘요"));
     }
 
     @Test

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/question/QuestionListTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/question/QuestionListTest.java
@@ -1,6 +1,7 @@
 package com.codewarts.noriter.article.docs.question;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpHeaders.CONNECTION;
 import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
@@ -105,6 +106,18 @@ class QuestionListTest {
 
             .then()
             .statusCode(HttpStatus.OK.value())
-            .body("size()", is(4));
+            .body("size()", is(4))
+            .body("[0].id", equalTo(6))
+            .body("[0].title", equalTo("질문1"))
+            .body("[0].content", equalTo("궁금1"))
+            .body("[0].writerNickname", equalTo("admin1"))
+            .body("[0].sameWriter", equalTo(false))
+            .body("[0].writtenTime", equalTo("2022-11-11 16:25:58"))
+            .body("[0].editedTime", equalTo("2022-11-11 16:25:58"))
+            .body("[0].hashtags[0]", equalTo("스프링"))
+            .body("[0].hashtags[1]", equalTo("코린이"))
+            .body("[0].hashtags[2]", equalTo("도와줘요"))
+            .body("[0].wishCount", equalTo(0))
+            .body("[0].commentCount", equalTo(0));
     }
 }

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyDetailTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyDetailTest.java
@@ -87,9 +87,9 @@ public class StudyDetailTest {
             .body("writer.profileImage",
                 equalTo("https://avatars.githubusercontent.com/u/111111?v=4"))
             .body("sameWriter", equalTo(false))
-            .body("hashtag[0]", equalTo("SPRING"))
-            .body("hashtag[1]", equalTo("JPA"))
-            .body("hashtag[2]", equalTo("난자유야"))
+            .body("hashtags[0]", equalTo("SPRING"))
+            .body("hashtags[1]", equalTo("JPA"))
+            .body("hashtags[2]", equalTo("난자유야"))
             .body("wishCount", equalTo(0))
             .body("status", equalTo("INCOMPLETE"))
             .body("comment[0].id", equalTo(1))

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyListTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/study/StudyListTest.java
@@ -83,8 +83,10 @@ class StudyListTest {
             .body("[0].content", equalTo("안녕하냐고오옹"))
             .body("[0].writerNickname", equalTo("admin1"))
             .body("[0].sameWriter", equalTo(false))
-            .body("[0].hashtag[0]", equalTo("SPRING"))
-            .body("[0].hashtag[1]", equalTo("JPA"))
+            .body("[0].writtenTime", equalTo("2022-11-11 16:25:58"))
+            .body("[0].editedTime", equalTo("2022-11-11 16:25:58"))
+            .body("[0].hashtags[0]", equalTo("SPRING"))
+            .body("[0].hashtags[1]", equalTo("JPA"))
             .body("[0].wishCount", equalTo(0))
             .body("[0].commentCount", equalTo(4));
     }


### PR DESCRIPTION
- 클라이언트 연동을 위해 날짜를 YYYY-DD-MM hh:mm:ss 형식으로 변경
- 글 작성시 클라이언트가 해당 글의 상세 페이지를 보여줄 수 있도록 articleId를 반환하도록 변경