### PR TITLE
찜 취소 기능 구현

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/exception/type/WishExceptionType.java
+++ b/noriter/src/main/java/com/codewarts/noriter/exception/type/WishExceptionType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum WishExceptionType implements ExceptionType {
 
-    WISH_ALREADY_EXIST("WISH001", "이미 찜한 게시글은 찜할 수 없습니다.", HttpStatus.NOT_FOUND);
+    WISH_ALREADY_EXIST("WISH001", "이미 찜한 게시글은 찜할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_CANCEL_NOT_EXIST_WISH("WISH002", "찜하지 않은 게시글은 취소할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/noriter/src/main/java/com/codewarts/noriter/wish/controller/WishController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/wish/controller/WishController.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +34,18 @@ public class WishController {
         Long memberId = getMemberId(request);
         wishService.create(memberId, map.get("articleId"));
     }
+
+    @DeleteMapping
+    public void remove(@RequestBody Map<String,
+        @Valid @NotNull(message = "ID가 비어있습니다.") @Positive(message = "게시글 ID는 양수이어야 합니다.") Long> map,
+        HttpServletRequest request) {
+        if (!map.containsKey("articleId")) {
+            throw new GlobalNoriterException(CommonExceptionType.INVALID_REQUEST);
+        }
+        Long memberId = getMemberId(request);
+        wishService.delete(memberId, map.get("articleId"));
+    }
+
 
     private Long getMemberId(HttpServletRequest request) {
         return (Long) request.getAttribute("memberId");

--- a/noriter/src/main/java/com/codewarts/noriter/wish/repository/WishRepository.java
+++ b/noriter/src/main/java/com/codewarts/noriter/wish/repository/WishRepository.java
@@ -3,9 +3,11 @@ package com.codewarts.noriter.wish.repository;
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.member.domain.Member;
 import com.codewarts.noriter.wish.domain.Wish;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
-    boolean existsWishByArticleAndAndMember(Article article, Member member);
+    boolean existsByArticleAndMember(Article article, Member member);
+    Optional<Wish> findByArticleAndMember(Article article, Member member);
 }

--- a/noriter/src/main/java/com/codewarts/noriter/wish/service/WishService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/wish/service/WishService.java
@@ -26,10 +26,24 @@ public class WishService {
             .orElseThrow(() -> new GlobalNoriterException(
                 ArticleExceptionType.ARTICLE_NOT_FOUND));
 
-        boolean existsWish = wishRepository.existsWishByArticleAndAndMember(article, member);
+        boolean existsWish = wishRepository.existsByArticleAndMember(article, member);
         if (existsWish) {
             throw new GlobalNoriterException(WishExceptionType.WISH_ALREADY_EXIST);
         }
         wishRepository.save(new Wish(member, article));
+    }
+
+    public void delete(Long memberId, Long articleId) {
+        Member member = memberService.findMember(memberId);
+        Article article = articleRepository.findById(articleId)
+            .orElseThrow(() -> new GlobalNoriterException(
+                ArticleExceptionType.ARTICLE_NOT_FOUND));
+
+        Wish wish = wishRepository.findByArticleAndMember(article, member)
+            .orElseThrow(() -> new GlobalNoriterException(
+                WishExceptionType.CANNOT_CANCEL_NOT_EXIST_WISH
+            ));
+
+        wishRepository.delete(wish);
     }
 }

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/wish/WishDeleteTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/wish/WishDeleteTest.java
@@ -1,0 +1,161 @@
+package com.codewarts.noriter.article.docs.wish;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONNECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.DATE;
+import static org.springframework.http.HttpHeaders.HOST;
+import static org.springframework.http.HttpHeaders.TRANSFER_ENCODING;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.codewarts.noriter.auth.jwt.JwtProvider;
+import com.codewarts.noriter.exception.type.ArticleExceptionType;
+import com.codewarts.noriter.exception.type.CommonExceptionType;
+import com.codewarts.noriter.exception.type.WishExceptionType;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith({RestDocumentationExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile({"test"})
+@Sql("classpath:/data.sql")
+class WishDeleteTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected RequestSpecification documentationSpec;
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        documentationSpec = new RequestSpecBuilder()
+            .addFilter(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(HOST, CONTENT_LENGTH))
+                    .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(CONTENT_LENGTH, CONNECTION, DATE, TRANSFER_ENCODING,
+                            "Keep-Alive",
+                            HttpHeaders.VARY))
+            )
+            .build();
+    }
+
+    @Test
+    void 찜을_취소한다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(Collections.singletonMap("articleId", 3))
+
+            .when()
+            .delete("/wish")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void articleId가_null인_경우_예외를_발생시킨다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(Collections.singletonMap("articleId", null))
+
+            .when()
+            .delete("/wish")
+
+            .then()
+            .statusCode(CommonExceptionType.INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(CommonExceptionType.INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("remove.map[articleId].<map value>: ID가 비어있습니다."));
+    }
+
+    @Test
+    void 찜하지_않은_게시글을_요청했을_경우_예외를_발생시킨다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(Collections.singletonMap("articleId", 1))
+
+            .when()
+            .delete("/wish")
+
+            .then()
+            .statusCode(WishExceptionType.CANNOT_CANCEL_NOT_EXIST_WISH.getStatus().value())
+            .body("errorCode", equalTo(WishExceptionType.CANNOT_CANCEL_NOT_EXIST_WISH.getErrorCode()))
+            .body("message", equalTo(WishExceptionType.CANNOT_CANCEL_NOT_EXIST_WISH.getErrorMessage()));
+    }
+
+    @Test
+    void articleId가_유효하지_않는_경우_예외를_발생시킨다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(Collections.singletonMap("articleId", -2))
+
+            .when()
+            .delete("/wish")
+
+            .then()
+            .statusCode(CommonExceptionType.INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(CommonExceptionType.INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("remove.map[articleId].<map value>: 게시글 ID는 양수이어야 합니다."));
+    }
+
+
+    @Test
+    void articleId가_존재하지_않는_경우_예외를_발생시킨다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(Collections.singletonMap("articleId", 999999))
+
+            .when()
+            .delete("/wish")
+
+            .then()
+            .statusCode(ArticleExceptionType.ARTICLE_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(ArticleExceptionType.ARTICLE_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(ArticleExceptionType.ARTICLE_NOT_FOUND.getErrorMessage()));
+    }
+}


### PR DESCRIPTION
## 📃 Description
💬 찜을 취소한다.

## ➡️ Request

### Header

Authorization : `AccessToken`

 DELETE `/wish`

### Body

```json
{
	"articleId" : 1 
}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{}
```

## 실패 CASE 요약

- 엑세스 토큰 없이 요청이 들어올때 `401`
- access token이 변조된 경우 `401`
- access token이 만료된 경우 `401`
- token의 id에 해당하는 회원이 db에 없는 경우 `401`
- 요청 시 필드값이 비어있는 경우 `400`
- 중복으로 찜 취소 요청 보낸 경우 `400`
- 다른사람의 찜을 취소 요청 보낸 경우 `401`

## ⭕️ 실패 CASE 1 : 요청 시 보낸 `AccessToken` 의 값이 비어있는 경우(null 또는 빈 문자열)

## ➡️ Request

### Header

Authorization : `null` or `blank`

DELETE `/community/playground`

### Body

```json
{
	"title" : "자유게시판 제목",
	"content" : "자유게시판 내용",
	"hashtag": ["키보드", "적축"]
}
```

## ⬅️ Reponse

### Header

http status : 401

### Body

```json
{
	"errorCode" : "AUTH00",
	"message" : "비어있는 Access-Token 입니다."
}
```

## ⭕️ 실패 CASE 2 : 요청 시 보낸 `AccessToken` 이 변조된 경우

## ➡️ Request

### Header

Authorization : `변조된 AccessToken`

DELETE `/community/playground`

### Body

```json
{
	"title" : "자유게시판 제목",
	"content" : "자유게시판 내용",
	"hashtag": ["키보드", "적축"]
}
```

## ⬅️ Reponse

### Header

http status : 401

### Body

```json
{
	"errorCode" : "AUTH00",
	"message" : "변조된 Access-Token 입니다."
}
```

## ⭕️ 실패 CASE 3 : 요청 시 보낸 `AccessToken` 이 만료된 경우

## ➡️ Request

### Header

Authorization : `만료된 AccessToken`

DELETE `/community/playground`

### Body

```json
{
	"title" : "자유게시판 제목",
	"content" : "자유게시판 내용",
	"hashtag": ["키보드", "적축"]
}
```

## ⬅️ Reponse

### Header

http status : 401

### Body

```json
{
	"errorCode" : "AUTH00",
	"message" : "만료된 Access-Token 입니다."
}
```

## ⭕️ 실패 CASE 4 : 요청 시 보낸 `AccessToken` 내 memberId가 존재하지 않는 경우

## ➡️ Request

### Header

Authorization : `AccessToken`

DELETE `/community/playground`

### Body

```json
{
	"title" : "자유게시판 제목",
	"content" : "자유게시판 내용",
	"wrtierId" : 11111111,//DB내 존재하지 않은 memberId
	"hashtag": ["키보드", "적축"]
}
```

## ⬅️ Reponse

### Header

http status : 401

### Body

```json
{
	"errorCode" : "MEMBER00",
	"message" : "존재하지 않은 회원입니다."
}
```

## 실패 CASE 5 : 요청 시 필드값이 비어있는 경우

## ➡️ Request

### Header

Authorization : `AccessToken`

DELETE `/wish`

### Body

```json
{
	"articleId" : 1
}
```

## ⬅️ Reponse

### Header

http status : 400

### Body

```json
{
	"errorCode" : "INVALID001",
	"message" : "잘못된 요청입니다."
}
```

## 실패 CASE 6 : 중복으로 찜 취소 요청 보낸 경우

## ➡️ Request

### Header

Authorization : `AccessToken`

DELETE `/wish`

### Body

```json
{
	"articleId" : 1
}
```

## ⬅️ Reponse

### Header

http status : 400

### Body

```json
{
	"errorCode" : "WISH002",
	"message" : "찜하지 않은 게시글은 취소할 수 없습니다."
}
```

## 실패 CASE 6 : 다른 사람의 찜을 취소 요청 보낸 경우

## ☑ Todo


## etc
