### PR TITLE
댓글 등록 기능 구현

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/article/dto/free/FreeDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/dto/free/FreeDetailResponse.java
@@ -2,7 +2,7 @@ package com.codewarts.noriter.article.dto.free;
 
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.domain.Hashtag;
-import com.codewarts.noriter.comment.dto.CommentResponse;
+import com.codewarts.noriter.comment.dto.comment.CommentResponse;
 import com.codewarts.noriter.member.dto.WriterInfoResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;

--- a/noriter/src/main/java/com/codewarts/noriter/article/dto/question/QuestionDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/dto/question/QuestionDetailResponse.java
@@ -3,7 +3,7 @@ package com.codewarts.noriter.article.dto.question;
 import com.codewarts.noriter.article.domain.Hashtag;
 import com.codewarts.noriter.article.domain.Question;
 import com.codewarts.noriter.article.domain.type.StatusType;
-import com.codewarts.noriter.comment.dto.CommentResponse;
+import com.codewarts.noriter.comment.dto.comment.CommentResponse;
 import com.codewarts.noriter.member.dto.WriterInfoResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;

--- a/noriter/src/main/java/com/codewarts/noriter/article/dto/study/StudyDetailResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/article/dto/study/StudyDetailResponse.java
@@ -3,7 +3,7 @@ package com.codewarts.noriter.article.dto.study;
 import com.codewarts.noriter.article.domain.Hashtag;
 import com.codewarts.noriter.article.domain.Study;
 import com.codewarts.noriter.article.domain.type.StatusType;
-import com.codewarts.noriter.comment.dto.CommentResponse;
+import com.codewarts.noriter.comment.dto.comment.CommentResponse;
 import com.codewarts.noriter.member.dto.WriterInfoResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;

--- a/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.codewarts.noriter.comment.controller;
 
+import com.codewarts.noriter.comment.dto.CommentPostRequest;
 import com.codewarts.noriter.comment.dto.recomment.ReCommentRequest;
 import com.codewarts.noriter.comment.service.CommentService;
 import javax.servlet.http.HttpServletRequest;
@@ -34,10 +35,14 @@ public class CommentController {
         Long memberId = getMemberId(request);
 
         commentService.createReComment(articleId, commentId, memberId, reCommentRequest);
+
+    @PostMapping
+    public void registerComment(@PathVariable Long articleId, @RequestBody CommentPostRequest commentRequest, HttpServletRequest request) {
+        Long memberId = getMemberId(request);
+        commentService.create(memberId, articleId, commentRequest);
     }
 
     private Long getMemberId(HttpServletRequest request) {
         return (Long) request.getAttribute("memberId");
     }
-
 }

--- a/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
@@ -1,6 +1,6 @@
 package com.codewarts.noriter.comment.controller;
 
-import com.codewarts.noriter.comment.dto.CommentPostRequest;
+import com.codewarts.noriter.comment.dto.comment.CommentPostRequest;
 import com.codewarts.noriter.comment.dto.recomment.ReCommentRequest;
 import com.codewarts.noriter.comment.service.CommentService;
 import javax.servlet.http.HttpServletRequest;
@@ -22,24 +22,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+    @PostMapping
+    public void registerComment(
+        @PathVariable(required = false)
+        @NotNull(message = "ID가 비어있습니다.")
+        @Positive(message = "게시글 ID는 양수이어야 합니다.") Long articleId,
+        @RequestBody @Valid CommentPostRequest commentRequest,
+        HttpServletRequest request) {
+        Long memberId = getMemberId(request);
+        commentService.createComment(memberId, articleId, commentRequest);
+    }
 
     @PostMapping("/{commentId}/recomment")
-    public void registerReComment(@PathVariable(required = false)
-    @NotNull(message = "ID가 비어있습니다.")
-    @Positive(message = "게시글 ID는 양수이어야 합니다.") Long articleId,
+    public void registerReComment(
+        @PathVariable(required = false)
+        @NotNull(message = "ID가 비어있습니다.")
+        @Positive(message = "게시글 ID는 양수이어야 합니다.") Long articleId,
         @PathVariable(required = false)
         @NotNull(message = "ID가 비어있습니다.")
         @Positive(message = "댓글 ID는 양수이어야 합니다.") Long commentId,
         @RequestBody @Valid ReCommentRequest reCommentRequest,
         HttpServletRequest request) {
         Long memberId = getMemberId(request);
-
         commentService.createReComment(articleId, commentId, memberId, reCommentRequest);
-
-    @PostMapping
-    public void registerComment(@PathVariable Long articleId, @RequestBody CommentPostRequest commentRequest, HttpServletRequest request) {
-        Long memberId = getMemberId(request);
-        commentService.create(memberId, articleId, commentRequest);
     }
 
     private Long getMemberId(HttpServletRequest request) {

--- a/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
@@ -14,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,4 +43,18 @@ public class Comment {
   private boolean deleted;
   private LocalDateTime writtenTime;
   private LocalDateTime editedTime;
+
+  @Builder
+  public Comment(Long id, Article article, List<ReComment> reComments, Member writer,
+      String content, boolean secret, boolean deleted, LocalDateTime writtenTime, LocalDateTime editedTime) {
+    this.id = id;
+    this.article = article;
+    this.reComments = reComments;
+    this.writer = writer;
+    this.content = content;
+    this.secret = secret;
+    this.deleted = deleted;
+    this.writtenTime = writtenTime;
+    this.editedTime = editedTime;
+  }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/comment/dto/CommentPostRequest.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/dto/CommentPostRequest.java
@@ -1,0 +1,29 @@
+package com.codewarts.noriter.comment.dto;
+
+import com.codewarts.noriter.article.domain.Article;
+import com.codewarts.noriter.comment.domain.Comment;
+import com.codewarts.noriter.member.domain.Member;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentPostRequest {
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+    private boolean secret;
+
+    public Comment toEntity(Article article, Member writer) {
+        return Comment.builder()
+            .article(article)
+            .writer(writer)
+            .content(content)
+            .secret(secret)
+            .writtenTime(LocalDateTime.now())
+            .editedTime(LocalDateTime.now())
+            .build();
+    }
+}

--- a/noriter/src/main/java/com/codewarts/noriter/comment/dto/comment/CommentPostRequest.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/dto/comment/CommentPostRequest.java
@@ -1,10 +1,11 @@
-package com.codewarts.noriter.comment.dto;
+package com.codewarts.noriter.comment.dto.comment;
 
 import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.comment.domain.Comment;
 import com.codewarts.noriter.member.domain.Member;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +15,8 @@ public class CommentPostRequest {
 
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
-    private boolean secret;
+    @NotNull(message = "내용은 필수입니다.")
+    private Boolean secret;
 
     public Comment toEntity(Article article, Member writer) {
         return Comment.builder()

--- a/noriter/src/main/java/com/codewarts/noriter/comment/dto/comment/CommentResponse.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/dto/comment/CommentResponse.java
@@ -1,4 +1,4 @@
-package com.codewarts.noriter.comment.dto;
+package com.codewarts.noriter.comment.dto.comment;
 
 import com.codewarts.noriter.comment.domain.Comment;
 import com.codewarts.noriter.member.dto.WriterInfoResponse;

--- a/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.repository.ArticleRepository;
 import com.codewarts.noriter.comment.domain.Comment;
 import com.codewarts.noriter.comment.domain.ReComment;
+import com.codewarts.noriter.comment.dto.CommentPostRequest;
 import com.codewarts.noriter.comment.dto.recomment.ReCommentRequest;
 import com.codewarts.noriter.comment.repository.CommentRepository;
 import com.codewarts.noriter.comment.repository.ReCommentRepository;
@@ -14,16 +15,26 @@ import com.codewarts.noriter.member.domain.Member;
 import com.codewarts.noriter.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CommentService {
 
-    private final ReCommentRepository reCommentRepository;
     private final CommentRepository commentRepository;
+    private final ReCommentRepository reCommentRepository;
     private final ArticleRepository articleRepository;
     private final MemberService memberService;
 
+    @Transactional
+    public void createComment(Long memberId, Long articleId, CommentPostRequest request) {
+        Member member = memberService.findMember(memberId);
+        Article article = findArticle(articleId);
+        Comment comment = request.toEntity(article, member);
+        commentRepository.save(comment);
+    }
+    @Transactional
     public void createReComment(Long articleId, Long commentId, Long memberId,
         ReCommentRequest request) {
         Article article = articleRepository.findById(articleId)
@@ -40,5 +51,10 @@ public class CommentService {
 
         ReComment reComment = request.toEntity(comment, member);
         reCommentRepository.save(reComment);
+    }
+
+    public Article findArticle(Long id) {
+        return articleRepository.findById(id)
+            .orElseThrow(() -> new GlobalNoriterException(ArticleExceptionType.ARTICLE_NOT_FOUND));
     }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
@@ -4,7 +4,7 @@ import com.codewarts.noriter.article.domain.Article;
 import com.codewarts.noriter.article.repository.ArticleRepository;
 import com.codewarts.noriter.comment.domain.Comment;
 import com.codewarts.noriter.comment.domain.ReComment;
-import com.codewarts.noriter.comment.dto.CommentPostRequest;
+import com.codewarts.noriter.comment.dto.comment.CommentPostRequest;
 import com.codewarts.noriter.comment.dto.recomment.ReCommentRequest;
 import com.codewarts.noriter.comment.repository.CommentRepository;
 import com.codewarts.noriter.comment.repository.ReCommentRepository;
@@ -30,7 +30,7 @@ public class CommentService {
     @Transactional
     public void createComment(Long memberId, Long articleId, CommentPostRequest request) {
         Member member = memberService.findMember(memberId);
-        Article article = findArticle(articleId);
+        Article article = findNotDeletedArticle(articleId);
         Comment comment = request.toEntity(article, member);
         commentRepository.save(comment);
     }
@@ -53,8 +53,12 @@ public class CommentService {
         reCommentRepository.save(reComment);
     }
 
-    public Article findArticle(Long id) {
-        return articleRepository.findById(id)
+    public Article findNotDeletedArticle(Long id) {
+        Article article = articleRepository.findById(id)
             .orElseThrow(() -> new GlobalNoriterException(ArticleExceptionType.ARTICLE_NOT_FOUND));
+        if (article.isDeleted()) {
+            throw new GlobalNoriterException(ArticleExceptionType.ARTICLE_NOT_FOUND);
+        }
+        return article;
     }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/common/config/WebConfig.java
+++ b/noriter/src/main/java/com/codewarts/noriter/common/config/WebConfig.java
@@ -40,7 +40,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new AuthVerificationInterceptor(jwtProvider)).order(1)
             .addPathPatterns("/community/playground", "/community/playground/{id}",
                 "/community/gathering", "/community/gathering/{id}", "/community/question",
-                "/community/question/{id}", "/wish", "/{articleId}/comment/{commentId}/recomment");
+                "/community/question/{id}", "/wish", "/{articleId}/comment",
+                "/{articleId}/comment/{commentId}/recomment");
     }
 
     @Override

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentCreateTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentCreateTest.java
@@ -1,0 +1,89 @@
+package com.codewarts.noriter.article.docs.comment;
+
+import static io.restassured.RestAssured.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONNECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.DATE;
+import static org.springframework.http.HttpHeaders.HOST;
+import static org.springframework.http.HttpHeaders.TRANSFER_ENCODING;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.codewarts.noriter.auth.jwt.JwtProvider;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith({RestDocumentationExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile({"test"})
+@Sql("classpath:/data.sql")
+class CommentCreateTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected RequestSpecification documentationSpec;
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        documentationSpec = new RequestSpecBuilder()
+            .addFilter(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(HOST, CONTENT_LENGTH))
+                    .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(CONTENT_LENGTH, CONNECTION, DATE, TRANSFER_ENCODING,
+                            "Keep-Alive",
+                            HttpHeaders.VARY))
+            )
+            .build();
+    }
+
+    @Test
+    void 댓글을_등록한다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(requestBody)
+
+            .when()
+            .post("/1/comment")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+
+}

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentCreateTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentCreateTest.java
@@ -1,6 +1,12 @@
 package com.codewarts.noriter.article.docs.comment;
 
+import static com.codewarts.noriter.exception.type.ArticleExceptionType.ARTICLE_NOT_FOUND;
+import static com.codewarts.noriter.exception.type.AuthExceptionType.EMPTY_ACCESS_TOKEN;
+import static com.codewarts.noriter.exception.type.AuthExceptionType.TAMPERED_ACCESS_TOKEN;
+import static com.codewarts.noriter.exception.type.CommonExceptionType.INVALID_REQUEST;
+import static com.codewarts.noriter.exception.type.MemberExceptionType.MEMBER_NOT_FOUND;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONNECTION;
 import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
@@ -76,14 +82,186 @@ class CommentCreateTest {
         given(documentationSpec)
             .contentType(APPLICATION_JSON_VALUE)
             .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
             .body(requestBody)
 
             .when()
-            .post("/1/comment")
+            .post("/{articleId}/comment")
 
             .then()
             .statusCode(HttpStatus.OK.value());
     }
 
+    @Test
+    void Access_Token이_비어있는_경우_예외_발생() {
+        String accessToken = " ";
 
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+
+            .then()
+            .statusCode(EMPTY_ACCESS_TOKEN.getStatus().value())
+            .body("errorCode", equalTo(EMPTY_ACCESS_TOKEN.getErrorCode()))
+            .body("message", equalTo(EMPTY_ACCESS_TOKEN.getErrorMessage()));
+    }
+
+    @Test
+    void Access_Token이_변조된_경우_예외_발생() {
+        String accessToken = jwtProvider.issueAccessToken(1L) + "123";
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+
+            .then()
+            .statusCode(TAMPERED_ACCESS_TOKEN.getStatus().value())
+            .body("errorCode", equalTo(TAMPERED_ACCESS_TOKEN.getErrorCode()))
+            .body("message", equalTo(TAMPERED_ACCESS_TOKEN.getErrorMessage()));
+    }
+
+    @Test
+    void 존재하지_않는_회원인_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(99999999L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+
+            .then()
+            .statusCode(MEMBER_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(MEMBER_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(MEMBER_NOT_FOUND.getErrorMessage()));
+    }
+
+    @Test
+    void 필수값이_비어있을_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("content", "");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo(INVALID_REQUEST.getErrorMessage()))
+            .body("detail.content", equalTo("내용은 필수입니다."))
+            .body("detail.secret", equalTo("내용은 필수입니다."));
+    }
+
+    @Test
+    void articleId가_Null이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", " ")
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("registerComment.articleId: ID가 비어있습니다."));
+    }
+
+    @Test
+    void articleId가_음수이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", -1)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("registerComment.articleId: 게시글 ID는 양수이어야 합니다."));
+    }
+
+    @Test
+    void articleId가_존재하지_않는_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 99999999)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+            .then()
+            .statusCode(ARTICLE_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(ARTICLE_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(ARTICLE_NOT_FOUND.getErrorMessage()));
+    }
+
+    @Test
+    void articleId가_삭제된_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        Map<String, Object> requestBody = Map.of("content", "댓글이에요",
+            "secret", "true");
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 13)
+            .body(requestBody)
+
+            .when()
+            .post("/{articleId}/comment")
+            .then()
+            .statusCode(ARTICLE_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(ARTICLE_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(ARTICLE_NOT_FOUND.getErrorMessage()));
+    }
 }


### PR DESCRIPTION
게시판에 댓글을 등록한다.

## ➡️ Request

### Header

Authorization : `AccessToken`

POST `/{articleId}/comment`

### Body

```json
{
	"content" : "댓글 등록할겁니다."
}
```

## ⬅️ Reponse

### Header

http status : 200

### Body

```json
{}
```

## 실패 CASE 요약

- 엑세스 토큰 없이 요청이 들어올때 `401`
- access token이 변조된 경우 `401`
- access token이 만료된 경우 `401`
- token의 id에 해당하는 회원이 db에 없는 경우 `401`
- 요청시 필드값이 하나라도 비어있을 경우 `400`
- articleId가 유효하지 않은 경우(null, 음수인 경우) `400`
- articleId가 존재하지 않은 경우(진짜 존재하지 않은 경우, 딜리트된 경우) `400`