### PR TITLE
댓글 삭제 기능 구현 및 테스트

### DIFF
--- a/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -48,6 +49,19 @@ public class CommentController {
         HttpServletRequest request) {
         Long memberId = getMemberId(request);
         commentService.updateComment(memberId, articleId, commentId, commentRequest);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public void removeComment(
+        @PathVariable(required = false)
+        @NotNull(message = "ID가 비어있습니다.")
+        @Positive(message = "게시글 ID는 양수이어야 합니다.") Long articleId,
+        @PathVariable(required = false)
+        @NotNull(message = "ID가 비어있습니다.")
+        @Positive(message = "댓글 ID는 양수이어야 합니다.") Long commentId,
+        HttpServletRequest request) {
+        Long memberId = getMemberId(request);
+        commentService.deleteComment(memberId, articleId, commentId);
     }
 
     @PostMapping("/{commentId}/recomment")

--- a/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/domain/Comment.java
@@ -77,4 +77,8 @@ public class Comment {
       throw new GlobalNoriterException(CommentExceptionType.NOT_MATCHED_ARTICLE);
     }
   }
+
+  public void delete() {
+    this.deleted = true;
+  }
 }

--- a/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
+++ b/noriter/src/main/java/com/codewarts/noriter/comment/service/CommentService.java
@@ -46,6 +46,15 @@ public class CommentService {
         comment.update(request.getContent(), request.getSecret());
     }
 
+    public void deleteComment(Long memberId, Long articleId, Long commentId) {
+        Member member = memberService.findMember(memberId);
+        Article article = findNotDeletedArticle(articleId);
+        Comment comment = findNotDeletedComment(commentId);
+        comment.validateArticleOrThrow(article);
+        comment.validateWriterOrThrow(member);
+        comment.delete();
+    }
+
     public void createReComment(Long articleId, Long commentId, Long memberId,
         ReCommentRequest request) {
         Member member = memberService.findMember(memberId);

--- a/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentDeleteTest.java
+++ b/noriter/src/test/java/com/codewarts/noriter/article/docs/comment/CommentDeleteTest.java
@@ -1,0 +1,342 @@
+package com.codewarts.noriter.article.docs.comment;
+
+import static com.codewarts.noriter.exception.type.ArticleExceptionType.ARTICLE_NOT_FOUND;
+import static com.codewarts.noriter.exception.type.ArticleExceptionType.DELETED_ARTICLE;
+import static com.codewarts.noriter.exception.type.AuthExceptionType.EMPTY_ACCESS_TOKEN;
+import static com.codewarts.noriter.exception.type.AuthExceptionType.TAMPERED_ACCESS_TOKEN;
+import static com.codewarts.noriter.exception.type.CommentExceptionType.COMMENT_NOT_FOUND;
+import static com.codewarts.noriter.exception.type.CommentExceptionType.DELETED_COMMENT;
+import static com.codewarts.noriter.exception.type.CommentExceptionType.NOT_MATCHED_ARTICLE;
+import static com.codewarts.noriter.exception.type.CommentExceptionType.NOT_MATCHED_WRITER;
+import static com.codewarts.noriter.exception.type.CommonExceptionType.INVALID_REQUEST;
+import static com.codewarts.noriter.exception.type.MemberExceptionType.MEMBER_NOT_FOUND;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONNECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.DATE;
+import static org.springframework.http.HttpHeaders.HOST;
+import static org.springframework.http.HttpHeaders.TRANSFER_ENCODING;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.codewarts.noriter.auth.jwt.JwtProvider;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith({RestDocumentationExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Profile({"test"})
+@Sql("classpath:/data.sql")
+class CommentDeleteTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    protected RequestSpecification documentationSpec;
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        documentationSpec = new RequestSpecBuilder()
+            .addFilter(
+                documentationConfiguration(restDocumentation)
+                    .operationPreprocessors()
+                    .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(HOST, CONTENT_LENGTH))
+                    .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(CONTENT_LENGTH, CONNECTION, DATE, TRANSFER_ENCODING,
+                            "Keep-Alive",
+                            HttpHeaders.VARY))
+            )
+            .build();
+    }
+
+    @Test
+    void 댓글을_삭제한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void Access_Token이_비어있는_경우_예외_발생() {
+        String accessToken = " ";
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(EMPTY_ACCESS_TOKEN.getStatus().value())
+            .body("errorCode", equalTo(EMPTY_ACCESS_TOKEN.getErrorCode()))
+            .body("message", equalTo(EMPTY_ACCESS_TOKEN.getErrorMessage()));
+    }
+
+    @Test
+    void Access_Token이_변조된_경우_예외_발생() {
+        String accessToken = jwtProvider.issueAccessToken(1L) + "123";
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(TAMPERED_ACCESS_TOKEN.getStatus().value())
+            .body("errorCode", equalTo(TAMPERED_ACCESS_TOKEN.getErrorCode()))
+            .body("message", equalTo(TAMPERED_ACCESS_TOKEN.getErrorMessage()));
+    }
+
+    @Test
+    void 존재하지_않는_회원인_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(99999999L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(MEMBER_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(MEMBER_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(MEMBER_NOT_FOUND.getErrorMessage()));
+    }
+
+    @Test
+    void articleId가_Null이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", " ")
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("removeComment.articleId: ID가 비어있습니다."));
+    }
+
+    @Test
+    void articleId가_음수이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", -1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("removeComment.articleId: 게시글 ID는 양수이어야 합니다."));
+    }
+
+    @Test
+    void articleId가_존재하지_않는_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 9999999)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(ARTICLE_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(ARTICLE_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(ARTICLE_NOT_FOUND.getErrorMessage()));
+    }
+
+    @Test
+    void articleId가_삭제된_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 13)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(DELETED_ARTICLE.getStatus().value())
+            .body("errorCode", equalTo(DELETED_ARTICLE.getErrorCode()))
+            .body("message", equalTo(DELETED_ARTICLE.getErrorMessage()));
+    }
+
+    @Test
+    void commentId가_Null이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", " ")
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("removeComment.commentId: ID가 비어있습니다."));
+    }
+
+    @Test
+    void commentId가_음수이면_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", -1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(INVALID_REQUEST.getStatus().value())
+            .body("errorCode", equalTo(INVALID_REQUEST.getErrorCode()))
+            .body("message", equalTo("removeComment.commentId: 댓글 ID는 양수이어야 합니다."));
+    }
+
+    @Test
+    void commentId가_존재하지_않는_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 9999999)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(COMMENT_NOT_FOUND.getStatus().value())
+            .body("errorCode", equalTo(COMMENT_NOT_FOUND.getErrorCode()))
+            .body("message", equalTo(COMMENT_NOT_FOUND.getErrorMessage()));
+    }
+
+    @Test
+    void commentId가_삭제된_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 12)
+            .pathParam("commentId", 6)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(DELETED_COMMENT.getStatus().value())
+            .body("errorCode", equalTo(DELETED_COMMENT.getErrorCode()))
+            .body("message", equalTo(DELETED_COMMENT.getErrorMessage()));
+    }
+
+    @Test
+    void 작성자가_일치하지_않는_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(2L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 1)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(NOT_MATCHED_WRITER.getStatus().value())
+            .body("errorCode", equalTo(NOT_MATCHED_WRITER.getErrorCode()))
+            .body("message", equalTo(NOT_MATCHED_WRITER.getErrorMessage()));
+    }
+
+    @Test
+    void 해당_게시글의_댓글이_아닌_경우_예외가_발생한다() {
+        String accessToken = jwtProvider.issueAccessToken(1L);
+
+        given(documentationSpec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .pathParam("articleId", 2)
+            .pathParam("commentId", 1)
+
+            .when()
+            .delete("/{articleId}/comment/{commentId}")
+
+            .then()
+            .statusCode(NOT_MATCHED_ARTICLE.getStatus().value())
+            .body("errorCode", equalTo(NOT_MATCHED_ARTICLE.getErrorCode()))
+            .body("message", equalTo(NOT_MATCHED_ARTICLE.getErrorMessage()));
+    }
+}


### PR DESCRIPTION
소프트 딜리트를 통해 댓글 삭제를 구현하였습니다.

### 테스트 목록

- 엑세스 토큰 없이 요청이 들어올때 `401`
- access token이 변조된 경우 `401`
- access token이 만료된 경우 `401`
- token의 id에 해당하는 회원이 db에 없는 경우 `401`
- articleId가 유효하지 않은 경우(null, 음수인 경우) `400`
- articleId가 존재하지 않은 경우(진짜 존재하지 않은 경우, 딜리트된 경우) `400`
- commentId가 유효하지 않은 경우(null, 음수인 경우) `400`
- commentId가 존재하지 않은 경우(진짜 존재하지 않은 경우, 딜리트된 경우) `400`
- 글쓴이가 아닌 다른 사람이 삭제를 요청할 경우 `401`
- articleId의 article에 달린 댓글이 아닌 경우 `400`